### PR TITLE
feat(neto-gemstones): add region lock for world hopping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/netogemstones/NetoGemstonesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/netogemstones/NetoGemstonesConfig.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.netogemstones;
 
 import net.runelite.client.config.Config;
+import net.runelite.http.api.worlds.WorldRegion;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
@@ -23,5 +24,38 @@ public interface NetoGemstonesConfig extends Config {
     )
     default String GUIDE() {
         return "Start near a gem rock with a pickaxe in your inventory or equipped. Gems bag and charged Amulet of Glory very recommended.";
+    }
+
+    @ConfigItem(
+            keyName = "hopOnPlayerDetect",
+            name = "Hop on Player Detect",
+            description = "Hops to another world if a player is detected nearby.",
+            position = 1,
+            section = generalSettings
+    )
+    default boolean hopOnPlayerDetect() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "distance",
+            name = "Distance to hop",
+            description = "The distance in tiles to check for other players.",
+            position = 2,
+            section = generalSettings
+    )
+    default int distanceToHop() {
+        return 10;
+    }
+
+    @ConfigItem(
+            keyName = "worldRegion",
+            name = "World Region",
+            description = "The region to hop to.",
+            position = 3,
+            section = generalSettings
+    )
+    default WorldRegion worldRegion() {
+        return WorldRegion.ANY;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/netogemstones/NetoGemstonesScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/netogemstones/NetoGemstonesScript.java
@@ -44,7 +44,7 @@ public class NetoGemstonesScript extends Script {
 
                 switch (state) {
                     case MINING:
-                        doMining();
+                        doMining(config);
                         break;
                     case BANKING:
                         doBanking();
@@ -58,7 +58,7 @@ public class NetoGemstonesScript extends Script {
         return true;
     }
 
-    public void doMining() {
+    public void doMining(NetoGemstonesConfig config) {
         if (Rs2Inventory.isFull()) {
             state = NetoGemstonesState.BANKING;
             return;
@@ -67,6 +67,9 @@ public class NetoGemstonesScript extends Script {
         if (gemRock != null) {
             if (Rs2GameObject.interact(gemRock, "Mine")) {
                 Rs2Player.waitForXpDrop(Skill.MINING);
+                if (config.hopOnPlayerDetect()) {
+                    Rs2Player.hopIfPlayerDetected(1, 0, config.distanceToHop(), config.worldRegion() == net.runelite.http.api.worlds.WorldRegion.ANY ? null : config.worldRegion());
+                }
             }
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -46,6 +46,7 @@ import net.runelite.client.plugins.microbot.util.security.Login;
 import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
+import net.runelite.http.api.worlds.WorldRegion;
 import net.runelite.http.api.worlds.WorldResult;
 import net.runelite.http.api.worlds.WorldType;
 
@@ -567,6 +568,10 @@ public class Rs2Player {
      * @return {@code true} if the player detected and successfully hopped worlds, {@code false} otherwise.
      */
     public static boolean hopIfPlayerDetected(int amountOfPlayers, int time, int distance) {
+        return hopIfPlayerDetected(amountOfPlayers, time, distance, null);
+    }
+
+    public static boolean hopIfPlayerDetected(int amountOfPlayers, int time, int distance, WorldRegion region) {
         List<Rs2PlayerModel> players = getPlayers(player -> true).collect(Collectors.toList());
         long currentTime = System.currentTimeMillis();
 
@@ -589,13 +594,13 @@ public class Rs2Player {
             for (Rs2PlayerModel player : players) {
                 long detectionTime = playerDetectionTimes.getOrDefault(player, 0L);
                 if (currentTime - detectionTime >= time) {
-                    int randomWorld = Login.getRandomWorld(isMember());
+                    int randomWorld = Login.getRandomWorld(isMember(), region);
                     Microbot.hopToWorld(randomWorld);
                     return true;
                 }
             }
         } else if (players.size() >= amountOfPlayers) {
-            int randomWorld = Login.getRandomWorld(isMember());
+            int randomWorld = Login.getRandomWorld(isMember(), region);
             Microbot.hopToWorld(randomWorld);
             return true;
         }


### PR DESCRIPTION
Adds a new feature to the Neto Gemstones plugin that allows the player to select a specific region to hop to when a player is detected.

This feature is an extension of the previous hop-on-player-detect feature. A new dropdown menu has been added to the plugin settings to select the desired region.